### PR TITLE
Kepler field incorrect roll angle

### DIFF
--- a/K2fov/data/k2-campaign-parameters.json
+++ b/K2fov/data/k2-campaign-parameters.json
@@ -6,10 +6,10 @@
     "campaign": 1000,
     "ra": 290.66666667,
     "dec": 44.5,
-    "roll": 123.0,
+    "roll": 19.5,
     "start": "2009-05-13",
     "stop": "2013-05-14",
-    "comments": "Original Kepler field; roll is 33.0 + season*90",
+    "comments": "Original Kepler field; roll is 19.5 + season*90",
     "preliminary": "False"
   },
   "c1001": {


### PR DESCRIPTION
The boresight for the original Kepler field appears correct, but the roll angle is several degrees off as targets actually observed by Kepler fall far off silicon. Currently listed as 33 deg but empirically should be more like 19.5 deg (+ 90 deg * [0, 1, 2, 3])